### PR TITLE
Change loopback address 127.0.0.1 to localhost

### DIFF
--- a/valis.py
+++ b/valis.py
@@ -3,7 +3,7 @@ import socket
 from subprocess import run
 
 
-def ping(host="127.0.0.1"):
+def ping(host="localhost"):
     if host != "":
         ping_switch = "-c"
         ping_count = "1"


### PR DESCRIPTION
Change loopback address 127.0.0.1 to localhost to align with decision to use DNS entries for everything and not support IP addresses in input.